### PR TITLE
Exclude `X-Vault-AWS-IAM-Server-ID` header when not provided

### DIFF
--- a/src/main/java/com/provectus/kafka/connect/config/AwsIamAuth.java
+++ b/src/main/java/com/provectus/kafka/connect/config/AwsIamAuth.java
@@ -40,7 +40,11 @@ public class AwsIamAuth {
     private Map<String,String> getHeaders() throws URISyntaxException, UnsupportedEncodingException {
 
         Map<String,String> headers = new LinkedHashMap<>();
-        headers.put("X-Vault-AWS-IAM-Server-ID", serverId);
+
+        if (serverId != null && serverId != "") {
+            headers.put("X-Vault-AWS-IAM-Server-ID", serverId);
+        }
+
         headers.put(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded; charset=utf-8");
 
         DefaultRequest<String> defaultRequest = new DefaultRequest<>("sts");


### PR DESCRIPTION
Otherwise, if no `serverId` is given, Vault will respond with an error like:

```json
{
    "errors": [
        "Field validation failed: error converting input <base64-encode-of-request> for field \"iam_request_headers\": received non-string value for header key:X-Vault-AWS-IAM-Server-ID, val:[<nil>]"
    ]
}
```